### PR TITLE
Reduce container image size to under 100MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM golang:1.19
-ARG TMP_DIR=/tmp/ocm-toolbox
-WORKDIR ${TMP_DIR}
-ADD . ${TMP_DIR}
-RUN go build -o /usr/local/bin/ocm-toolbox cmd/main.go
-RUN rm -rf ${TMP_DIR}
+FROM golang:1.19 AS build
+WORKDIR /tmp/src
+COPY . /tmp/src
+RUN go build -o /tmp/ocm-toolbox cmd/main.go
+
+FROM alpine:latest
+COPY --from=build /tmp/ocm-toolbox /usr/local/bin/ocm-toolbox
 ENTRYPOINT [ "ocm-toolbox" ]


### PR DESCRIPTION
Previous container image size:

```
localhost/ocm-toolbox                                           main                  0e9e30d9852c  19 seconds ago  1.36 GB
```

New container image size:

```
localhost/ocm-toolbox                                           main                  3add9771c25d  2 minutes ago   32.7 MB
```

Closes #3 