### PR TITLE
Add command to extend cluster expiration timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,10 @@ Each sub-command will have different options and a help menu.
 ```shell
 ./out/ocm-toolbox cluster-credentials --cluster-id <CLUSTER_ID>
 ```
+
+3. Update cluster expiration timestamp
+
+```shell
+./out/ocm-toolbox set-cluster-expiration --cluster-id <CLUSTER_ID> \
+--duration 60
+```

--- a/cmd/clusterexpiration/clusterexpiration.go
+++ b/cmd/clusterexpiration/clusterexpiration.go
@@ -1,0 +1,43 @@
+package clusterexpiration
+
+import (
+	"github.com/ryankwilliams/ocm-toolbox/pkg/clusterexpiration"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "set-cluster-expiration",
+	Short: "Update a clusters expiration date",
+	Long:  "Update a clusters expiration date",
+	Run:   run,
+}
+
+var flags struct {
+	clusterID string
+	duration  int
+}
+
+func init() {
+	Cmd.Flags().StringVarP(
+		&flags.clusterID,
+		"cluster-id",
+		"",
+		"",
+		"OCM Cluster ID",
+	)
+	Cmd.Flags().IntVarP(
+		&flags.duration,
+		"duration",
+		"",
+		60,
+		"Total time (in minutes) to extend cluster expiration",
+	)
+	Cmd.MarkFlagRequired("cluster-id") // nolint:errcheck
+}
+
+func run(cmd *cobra.Command, argv []string) {
+	clusterexpiration.SetClusterExpirationTimestamp(
+		flags.clusterID,
+		flags.duration,
+	)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/ryankwilliams/ocm-toolbox/cmd/clusterdetails"
+	"github.com/ryankwilliams/ocm-toolbox/cmd/clusterexpiration"
 	"github.com/ryankwilliams/ocm-toolbox/cmd/credentials"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -51,6 +52,7 @@ func init() {
 
 	rootCmd.AddCommand(credentials.Cmd)
 	rootCmd.AddCommand(clusterdetails.Cmd)
+	rootCmd.AddCommand(clusterexpiration.Cmd)
 }
 
 func run(cmd *cobra.Command, argv []string) {}

--- a/pkg/clusterdetails/clusterdetails.go
+++ b/pkg/clusterdetails/clusterdetails.go
@@ -18,7 +18,7 @@ func ClusterDetails(clusterFilters *ClusterFilters) {
 	var presentClusters []*v1.Cluster
 
 	if clusterFilters.ID != "" {
-		cluster := ocm.GetCluster(clusterFilters.ID)
+		cluster := ocm.GetClusterBody(clusterFilters.ID)
 		presentClusters = make([]*v1.Cluster, 0)
 		presentClusters = append(presentClusters, cluster)
 	} else {

--- a/pkg/clusterexpiration/clusterexpiration.go
+++ b/pkg/clusterexpiration/clusterexpiration.go
@@ -1,0 +1,35 @@
+package clusterexpiration
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/ryankwilliams/ocm-toolbox/pkg/ocm"
+)
+
+func SetClusterExpirationTimestamp(clusterID string, duration int) {
+	ocm := ocm.Connect()
+
+	cluster, response := ocm.GetCluster(clusterID)
+	clusterDetails := response.Body()
+
+	fmt.Printf("Original expiration timestamp: %s\n", clusterDetails.ExpirationTimestamp())
+
+	patchedCluster, err := v1.NewCluster().
+		ExpirationTimestamp(clusterDetails.ExpirationTimestamp().Add(time.Duration(duration) * time.Minute)).
+		Build()
+	if err != nil {
+		fmt.Printf("Unable to patch cluster expiration timestamp: %s, error: %s", clusterID, err)
+		os.Exit(1)
+	}
+
+	_, err = cluster.Update().Body(patchedCluster).Send()
+	if err != nil {
+		fmt.Printf("Failed to update cluster expiration timestamp: %s, error: %s", clusterID, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Updated expiration timestamp: %s\n", patchedCluster.ExpirationTimestamp())
+}

--- a/pkg/ocm/core.go
+++ b/pkg/ocm/core.go
@@ -69,19 +69,25 @@ func (o *OCMInstance) ListClusters() *v1.ClusterList {
 	return clusters
 }
 
-func (o *OCMInstance) GetCluster(clusterID string) *v1.Cluster {
-	response, err := o.Connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Get().Send()
+func (o *OCMInstance) GetCluster(clusterID string) (*v1.ClusterClient, *v1.ClusterGetResponse) {
+	cluster := o.Connection.ClustersMgmt().V1().Clusters().Cluster(clusterID)
 
+	response, err := cluster.Get().Send()
 	if err != nil {
 		fmt.Printf("Unable to find cluster: %s in OCM, error: %s", clusterID, err)
 		os.Exit(1)
 	}
 
+	return cluster, response
+}
+
+func (o *OCMInstance) GetClusterBody(clusterID string) *v1.Cluster {
+	_, response := o.GetCluster(clusterID)
 	return response.Body()
 }
 
 func (o *OCMInstance) GetClusterCredentials(clusterID string) (string, *v1.ClusterCredentials) {
-	cluster := o.GetCluster(clusterID)
+	cluster := o.GetClusterBody(clusterID)
 
 	response, err := o.Connection.ClustersMgmt().V1().Clusters().
 		Cluster(clusterID).


### PR DESCRIPTION
PR adds a new command for extending (setting) the cluster expiration timestamp.

```shell
./out/ocm-toolbox set-cluster-expiration --cluster-id <CLUSTER_ID> --duration 120 --url staging
Original expiration timestamp: 2022-11-22 23:00:00 +0000 UTC
Updated expiration timestamp: 2022-11-23 01:00:00 +0000 UTC
```

Closes #1 