### PR TITLE
Add timeout to increase analysis timeout to 2 minutes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          args: --timeout 2m


### PR DESCRIPTION
Occassionally when the github action runs for verifying the code base for linting. It will fail trying to run. This commit includes the timeout arg and sets it to 2 minutes over the default 1 minute.