### PR TITLE
Set go version from 1.19 to 1.20 as 1.19 is no longer supported

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 AS build
+FROM golang:1.20 AS build
 WORKDIR /tmp/src
 COPY . /tmp/src
 RUN CGO_ENABLED=0 go build -o /tmp/ocm-toolbox

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ryankwilliams/ocm-toolbox
 
-go 1.19
+go 1.20
 
 require github.com/spf13/cobra v1.7.0
 


### PR DESCRIPTION
# Description
Go 1.19 is no longer supported. This PR sets the minimum version to 1.20.

https://endoflife.date/go
