### PR TITLE
Filter ARO from managed clusters monitoring list

### DIFF
--- a/pkg/ocm/core.go
+++ b/pkg/ocm/core.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -112,8 +113,7 @@ func (o *OCMInstance) ListManagedClusters(clusters []*v1.Cluster) []*v1.Cluster 
 	var clusterList []*v1.Cluster
 
 	for _, cluster := range clusters {
-	    cluster_id := cluster.Product().ID()
-		if cluster_id != "ocp" && cluster_id != "aro" {
+        if !slices.Contains([]string{"ocp", "aro"}, cluster.Product().ID()) {
 			clusterList = append(clusterList, cluster)
 		}
 	}

--- a/pkg/ocm/core.go
+++ b/pkg/ocm/core.go
@@ -113,7 +113,7 @@ func (o *OCMInstance) ListManagedClusters(clusters []*v1.Cluster) []*v1.Cluster 
 	var clusterList []*v1.Cluster
 
 	for _, cluster := range clusters {
-        if !slices.Contains([]string{"ocp", "aro"}, cluster.Product().ID()) {
+		if !slices.Contains([]string{"ocp", "aro"}, cluster.Product().ID()) {
 			clusterList = append(clusterList, cluster)
 		}
 	}

--- a/pkg/ocm/core.go
+++ b/pkg/ocm/core.go
@@ -113,7 +113,7 @@ func (o *OCMInstance) ListManagedClusters(clusters []*v1.Cluster) []*v1.Cluster 
 
 	for _, cluster := range clusters {
 	    cluster_id := cluster.Product().ID()
-		if cluster_type != "ocp" && cluster_type != "aro" {
+		if cluster_id != "ocp" && cluster_id != "aro" {
 			clusterList = append(clusterList, cluster)
 		}
 	}

--- a/pkg/ocm/core.go
+++ b/pkg/ocm/core.go
@@ -112,7 +112,8 @@ func (o *OCMInstance) ListManagedClusters(clusters []*v1.Cluster) []*v1.Cluster 
 	var clusterList []*v1.Cluster
 
 	for _, cluster := range clusters {
-		if cluster.Product().ID() != "ocp" {
+	    cluster_id := cluster.Product().ID()
+		if cluster_type != "ocp" && cluster_type != "aro" {
 			clusterList = append(clusterList, cluster)
 		}
 	}


### PR DESCRIPTION
ARO clusters aro not considered managed by OCM:
```
❯ ocm delete cluster $ARO_CLUSTER_ID 
{
  "kind": "Error",
  "id": "400",
  "href": "/api/clusters_mgmt/v1/errors/400",
  "code": "CLUSTERS-MGMT-400",
  "reason": "Failed to delete cluster 286vv6t18qb0t5f0nnbhslu341jp0h08: Cannot deprovision a cluster that is not managed",
  "operation_id": "44c7026a-e81e-4c3e-bb7f-97e7a578459c"
}
```

Therefore should be removed from managed clusters monitoring preview